### PR TITLE
Direct 'Work' navigation item to 'simplisafe.html' & update header to '@jwq1'

### DIFF
--- a/be-me.html
+++ b/be-me.html
@@ -29,7 +29,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" href="./maker-text.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/be-me.html
+++ b/be-me.html
@@ -23,7 +23,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/code.html
+++ b/code.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/code.html
+++ b/code.html
@@ -19,7 +19,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" href="./maker.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <body>
     <section class="container landing-page">
       <nav class="row navbar navbar-expand-lg navbar-light">
-        <a class="navbar-brand display-1" href="./index.html">John Quinn</a>
+        <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>

--- a/live.html
+++ b/live.html
@@ -29,7 +29,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" href="./maker-text.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/live.html
+++ b/live.html
@@ -23,7 +23,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/maker-text.html
+++ b/maker-text.html
@@ -24,7 +24,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/maker-text.html
+++ b/maker-text.html
@@ -30,7 +30,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link active" href="./maker-text.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/maker.html
+++ b/maker.html
@@ -19,7 +19,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./work.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/@jwq1">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>
           <a class="nav-item nav-link" href="./volunteer.html">Volunteer</a>

--- a/maker.html
+++ b/maker.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand" href="./index.html">jwq1</a>
+      <a class="navbar-brand" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/play.html
+++ b/play.html
@@ -29,7 +29,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" href="./maker-text.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/play.html
+++ b/play.html
@@ -23,7 +23,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/simplisafe.html
+++ b/simplisafe.html
@@ -24,7 +24,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/volunteer.html
+++ b/volunteer.html
@@ -29,7 +29,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./nielsen-page-quick.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" href="./maker-text.html">Make</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>

--- a/volunteer.html
+++ b/volunteer.html
@@ -23,7 +23,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/work.html
+++ b/work.html
@@ -30,7 +30,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./work.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>
           <a class="nav-item nav-link" href="./volunteer.html">Volunteer</a>

--- a/work.html
+++ b/work.html
@@ -24,7 +24,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/write.html
+++ b/write.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <nav class="container navbar navbar-expand-lg navbar-light">
-      <a class="navbar-brand display-1" href="./index.html">jwq1</a>
+      <a class="navbar-brand display-1" href="./index.html">@jwq1</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/write.html
+++ b/write.html
@@ -19,7 +19,7 @@
       </button>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
         <div class="navbar-nav">
-          <a class="nav-item nav-link" href="./work.html">Work</a>
+          <a class="nav-item nav-link" href="./simplisafe.html">Work</a>
           <a class="nav-item nav-link" target="_blank" href="https://medium.com/looking-back-at-now">Write</a>
           <a class="nav-item nav-link" target="_blank" href="https://github.com/jwq1">Code</a>
           <a class="nav-item nav-link" href="./volunteer.html">Volunteer</a>


### PR DESCRIPTION
The "Work" navigation bar item was still going to the "nielsen" page. I forgot to update the nav bar for anything other than the index.html page. All the other pages contained outdated code. 

I also added "@" in front of the jwq1 header to indicate that it's a way to contact me. Not sure I like it, but it's fine for now.